### PR TITLE
add tracing for the request body to understand production

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -11,6 +11,7 @@ class WebhooksController < ApplicationController
 
     signature = request.headers['HTTP_X_HUB_SIGNATURE']
     body = request.body.read
+    logger.debug "request body: '#{body}'"
     verify_signature(body, signature)
 
     payload = params[:payload]


### PR DESCRIPTION
Before I go and merge #11 I want to confirm I understand the raw request payload that gets received by us.

I believe it's JSON with the `payload` field being the event payload shown on GitHub, but the outer message is used to verify the signature in the header. I don't want to cut a shortcut here when testing, because it may end up breaking things in unexpected ways.