### PR TITLE
lib isn't included by default in autoload_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,9 @@ module Webhooks
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # this directory is not included by default
+    config.autoload_paths += %W[#{config.root}/lib]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
Tests from #11 didn't catch this, so yay!