### PR TITLE
make clear to rails that we shouldn't return any content

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -19,7 +19,7 @@ class WebhooksController < ApplicationController
       logger.info "No handler available for event type '#{event}' and project '#{project}'"
     end
 
-    :ok
+    head :no_content
   end
 
   def verify_signature


### PR DESCRIPTION
I think this will address the messages I see in production, by making explicit that this is fine:

```
No template found for WebhooksController#receive, rendering head :no_content
```