### PR TITLE
use vendor folder for gems instead of system install

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor"

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config.
-/.bundle
-
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
@@ -32,3 +29,6 @@ yarn-debug.log*
 
 # Simplecov
 coverage/
+
+# Vendored gems
+vendor/


### PR DESCRIPTION
This is a nuisance of mine on systems where you need `sudo` to write to the system gem directory (like Linux).

So rather than continuing to hit this and have to re-run the command, why not just vendor to a directory within the project?