### PR TITLE
pin ruby version to 3.0.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby 3.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0'
 
       - name: Install PostgreSQL 11 client
         run: |


### PR DESCRIPTION
Related to https://github.com/ruby/setup-ruby/issues/252 and how `3.0` is interpreted as `3` and is currently choosing `3.1` (i.e. the latest `3.x` release)...