### PR TITLE
require missing module

### DIFF
--- a/app/jobs/up_for_grabs_pull_request_project_analyzer_job.rb
+++ b/app/jobs/up_for_grabs_pull_request_project_analyzer_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 class UpForGrabsPullRequestProjectAnalyzerJob < ApplicationJob
   queue_as :default
 


### PR DESCRIPTION
```
NameError (uninitialized constant UpForGrabsPullRequestProjectAnalyzerJob::Open3
```

Totally missed this with some earlier change (Ruby 3 upgrade?)